### PR TITLE
Fixed to use only deviceSubType rcapture - iris

### DIFF
--- a/MockMDS/pom.xml
+++ b/MockMDS/pom.xml
@@ -193,6 +193,7 @@
 							<tasks>
 								<echo>Using env.test.properties</echo>
 								<copy file="run.bat" tofile="${basedir}/target/run.bat" />
+								<copy file="run.sh" tofile="${basedir}/target/run.sh" />
 							</tasks>
 						</configuration>
 					</execution>

--- a/MockMDS/run.sh
+++ b/MockMDS/run.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+
+echo "Starting MOCK MDS service..."
+
+nohup java -cp provider-0.0.1-SNAPSHOT.jar:lib/* org.biometric.provider.ProviderApplication > /tmp/mock_mds.log 2>&1 &
+
+echo "Started MOCK MDS service."

--- a/MockMDS/src/main/java/org/biometric/provider/DiscoverRequest.java
+++ b/MockMDS/src/main/java/org/biometric/provider/DiscoverRequest.java
@@ -226,7 +226,7 @@ public class DiscoverRequest extends HttpServlet {
 		try {
 			result = JwtUtility.getJwt(oB.writeValueAsBytes(digitalMap), JwtUtility.getPrivateKey(),
 					JwtUtility.getCertificate());
-		} catch (NoSuchAlgorithmException | InvalidKeySpecException | CertificateException | IOException e) {
+		} catch (IOException e) {
 			e.printStackTrace();
 		}
 		return result;

--- a/MockMDS/src/main/java/org/biometric/provider/InfoRequest.java
+++ b/MockMDS/src/main/java/org/biometric/provider/InfoRequest.java
@@ -325,7 +325,7 @@ public class InfoRequest extends HttpServlet {
 		try {
 			result = JwtUtility.getJwt(oB.writeValueAsBytes(digitalMap), JwtUtility.getPrivateKey(),
 					JwtUtility.getCertificate());
-		} catch (NoSuchAlgorithmException | InvalidKeySpecException | CertificateException | IOException e) {
+		} catch (IOException e) {
 			e.printStackTrace();
 		}
 		return result;

--- a/MockMDS/src/main/java/org/biometric/provider/JwtUtility.java
+++ b/MockMDS/src/main/java/org/biometric/provider/JwtUtility.java
@@ -36,10 +36,14 @@ public class JwtUtility {
 	public static String getJwt(byte[] data, PrivateKey privateKey, X509Certificate x509Certificate) {
 		String jwsToken = null;
 		JsonWebSignature jws = new JsonWebSignature();
-		List<X509Certificate> certList = new ArrayList<>();
-		certList.add(x509Certificate);
-		X509Certificate[] certArray = certList.toArray(new X509Certificate[] {});
-		jws.setCertificateChainHeaderValue(certArray);
+		
+		if(x509Certificate != null) {
+			List<X509Certificate> certList = new ArrayList<>();
+			certList.add(x509Certificate);
+			X509Certificate[] certArray = certList.toArray(new X509Certificate[] {});
+			jws.setCertificateChainHeaderValue(certArray);
+		}
+		
 		jws.setPayloadBytes(data);
 		jws.setAlgorithmHeaderValue(signAlgorithm);
 		jws.setKey(privateKey);
@@ -53,31 +57,38 @@ public class JwtUtility {
 
 	}
 
-	public static X509Certificate getCertificate()
-			throws IOException, NoSuchAlgorithmException, InvalidKeySpecException, CertificateException {
+	public static X509Certificate getCertificate() {
+		
+		try {
+			FileInputStream certfis = new FileInputStream(
 
-		FileInputStream certfis = new FileInputStream(
+					new File(System.getProperty("user.dir") + "/files/keys/MosipTestCert.pem").getPath());
 
-				new File(System.getProperty("user.dir") + "/files/keys/MosipTestCert.pem").getPath());
+			String cert = getFileContent(certfis, "UTF-8");
 
-		String cert = getFileContent(certfis, "UTF-8");
-
-		cert = trimBeginEnd(cert);
-		CertificateFactory cf = CertificateFactory.getInstance("X.509");
-		return (X509Certificate) cf.generateCertificate(new ByteArrayInputStream(Base64.getDecoder().decode(cert)));
-
+			cert = trimBeginEnd(cert);
+			CertificateFactory cf = CertificateFactory.getInstance("X.509");
+			return (X509Certificate) cf.generateCertificate(new ByteArrayInputStream(Base64.getDecoder().decode(cert)));
+		} catch (Exception ex) {
+			ex.printStackTrace();
+		}
+		return null;
 	}
 
-	public static PrivateKey getPrivateKey() throws IOException, NoSuchAlgorithmException, InvalidKeySpecException {
+	public static PrivateKey getPrivateKey() {		
+		try {
+			FileInputStream pkeyfis = new FileInputStream(
+					new File(System.getProperty("user.dir") + "/files/keys/PrivateKey.pem").getPath());
 
-		FileInputStream pkeyfis = new FileInputStream(
-				new File(System.getProperty("user.dir") + "/files/keys/PrivateKey.pem").getPath());
-
-		String pKey = getFileContent(pkeyfis, "UTF-8");
-		pKey = trimBeginEnd(pKey);
-		KeyFactory kf = KeyFactory.getInstance("RSA");
-		return kf.generatePrivate(new PKCS8EncodedKeySpec(Base64.getDecoder().decode(pKey)));
-
+			String pKey = getFileContent(pkeyfis, "UTF-8");
+			pKey = trimBeginEnd(pKey);
+			KeyFactory kf = KeyFactory.getInstance("RSA");
+			return kf.generatePrivate(new PKCS8EncodedKeySpec(Base64.getDecoder().decode(pKey)));
+		} catch (Exception ex) {
+			ex.printStackTrace();
+			//throw new Exception("Failed to get private key");
+		}
+		return null;
 	}
 	
 	public static PublicKey getPublicKey() throws IOException, NoSuchAlgorithmException, InvalidKeySpecException {


### PR DESCRIPTION
BioType match based on spec. 
Removed both deviceId and deviceSubId for constructing response, Only considers deviceSubType. 
Removed repeated code