### PR TITLE
Fix: Updated ExtractTemplateService and SDKService logic

### DIFF
--- a/mock-sdk/src/main/java/io/mosip/mock/sdk/service/ExtractTemplateService.java
+++ b/mock-sdk/src/main/java/io/mosip/mock/sdk/service/ExtractTemplateService.java
@@ -49,6 +49,9 @@ public class ExtractTemplateService extends SDKService {
 				LOGGER.info("extractTemplate segment size {}", sample.getSegments().size());
 				
 			for (BIR segment : sample.getSegments()) {
+				if (isValidException(segment.getOthers()))
+					break;
+
 				if (!isValidBirData(segment))
 					break;
 

--- a/mock-sdk/src/main/java/io/mosip/mock/sdk/service/SDKService.java
+++ b/mock-sdk/src/main/java/io/mosip/mock/sdk/service/SDKService.java
@@ -107,8 +107,6 @@ public abstract class SDKService {
 		System.out.println("SDKService.isValidException>> " + others);
 		if (others != null && !others.isEmpty() && others.containsKey("EXCEPTION")) {
 			String exceptionValue = others.get("EXCEPTION");
-			System.out.println("SDKService.isValidException>> Exception found with value: " + exceptionValue);
-			System.out.println("true".equalsIgnoreCase(exceptionValue));
 			return "true".equalsIgnoreCase(exceptionValue);
 		}
 		return false;

--- a/mock-sdk/src/main/java/io/mosip/mock/sdk/service/SDKService.java
+++ b/mock-sdk/src/main/java/io/mosip/mock/sdk/service/SDKService.java
@@ -104,7 +104,6 @@ public abstract class SDKService {
 	 * @return true if "Exception" is present and set to "true" (case-insensitive), false otherwise.
 	 */
 	protected boolean isValidException(Map<String, String> others) {
-		System.out.println("SDKService.isValidException>> " + others);
 		if (others != null && !others.isEmpty() && others.containsKey("EXCEPTION")) {
 			String exceptionValue = others.get("EXCEPTION");
 			return "true".equalsIgnoreCase(exceptionValue);

--- a/mock-sdk/src/main/java/io/mosip/mock/sdk/service/SDKService.java
+++ b/mock-sdk/src/main/java/io/mosip/mock/sdk/service/SDKService.java
@@ -97,6 +97,23 @@ public abstract class SDKService {
 		return bioSegmentMap;
 	}
 
+	/**
+	 * Checks if the "Exception" key exists in the provided map and its value is "true" (case-insensitive).
+	 *
+	 * @param others The map containing additional attributes.
+	 * @return true if "Exception" is present and set to "true" (case-insensitive), false otherwise.
+	 */
+	protected boolean isValidException(Map<String, String> others) {
+		System.out.println("SDKService.isValidException>> " + others);
+		if (others != null && !others.isEmpty() && others.containsKey("EXCEPTION")) {
+			String exceptionValue = others.get("EXCEPTION");
+			System.out.println("SDKService.isValidException>> Exception found with value: " + exceptionValue);
+			System.out.println("true".equalsIgnoreCase(exceptionValue));
+			return "true".equalsIgnoreCase(exceptionValue);
+		}
+		return false;
+	}
+
 	protected boolean isValidBirData(BIR bir) {
 		BiometricType biometricType = bir.getBdbInfo().getType().get(0);
 		PurposeType purposeType = bir.getBdbInfo().getPurpose();


### PR DESCRIPTION
Added a method isValidException that checks whether the input map contains the key "EXCEPTION" and if its value is "true". Returns true only if both conditions are met; otherwise, returns false.
