### PR TITLE
#2384: Update POM, helm chart and install script versions for 1.3.1 release

### DIFF
--- a/MockMDS/pom.xml
+++ b/MockMDS/pom.xml
@@ -5,7 +5,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>io.mosip.mock.mds</groupId>
 	<artifactId>mock-mds</artifactId>
-	<version>1.3.1-rc.1</version>
+	<version>1.3.1-SNAPSHOT</version>
 	<name>mock-mds</name>
 	<description>A mock project for biometric provider</description>
 	<url>https://github.com/mosip/mosip-mock-services</url>
@@ -49,8 +49,8 @@
 		<org.bitbucket.jose4j.version>0.7.1</org.bitbucket.jose4j.version>
 
 		<!-- Mosip -->
-		<kernel.bom.version>1.3.1-rc.1</kernel.bom.version>
-		<kernel.core.version>1.3.1-rc.1</kernel.core.version>
+		<kernel.bom.version>1.3.1-SNAPSHOT</kernel.bom.version>
+		<kernel.core.version>1.3.1-SNAPSHOT</kernel.core.version>
 		<mosip.biometrics.util.version>1.3.0</mosip.biometrics.util.version>
 		
 		<!-- Test -->

--- a/deploy/install.sh
+++ b/deploy/install.sh
@@ -7,7 +7,7 @@ if [ $# -ge 1 ] ; then
 fi
 
 NS=abis
-CHART_VERSION=1.3.1-rc.1-develop
+CHART_VERSION=1.3.1-develop
 
 echo Create $NS namespace
 kubectl create ns $NS

--- a/helm/mock-abis/Chart.yaml
+++ b/helm/mock-abis/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: mock-abis
 description: A Helm chart for MOSIP Mock ABIS
 type: application
-version: 1.3.1-rc.1-develop
+version: 1.3.1-develop
 appVersion: ""
 dependencies:
   - name: common

--- a/helm/mock-abis/values.yaml
+++ b/helm/mock-abis/values.yaml
@@ -44,8 +44,8 @@ service:
   externalTrafficPolicy: Cluster
 image:
   registry: docker.io
-  repository: mosipid/mock-abis
-  tag: 1.3.1-rc.1
+  repository: mosipqa/mock-abis
+  tag: 1.3.x
   ## Specify a imagePullPolicy
   ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
   ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images

--- a/helm/mock-mv/Chart.yaml
+++ b/helm/mock-mv/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: mock-mv
 description: A Helm chart for MOSIP Mock Manual Verification service
 type: application
-version: 1.3.1-rc.1-develop
+version: 1.3.1-develop
 appVersion: ""
 dependencies:
   - name: common

--- a/helm/mock-mv/values.yaml
+++ b/helm/mock-mv/values.yaml
@@ -46,8 +46,8 @@ service:
   externalTrafficPolicy: Cluster
 image:
   registry: docker.io
-  repository: mosipid/mock-mv
-  tag: 1.3.1-rc.1
+  repository: mosipqa/mock-mv
+  tag: 1.3.x
   ## Specify a imagePullPolicy
   ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
   ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images

--- a/mock-abis/pom.xml
+++ b/mock-abis/pom.xml
@@ -5,7 +5,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>io.mosip.mock.abis</groupId>
     <artifactId>mock-abis</artifactId>
-    <version>1.3.1-rc.1</version>
+    <version>1.3.1-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <name>MockAbis</name>
@@ -57,8 +57,8 @@
         </sonar.exclusions>
 
         <!-- Mosip -->
-        <kernel.bom.version>1.3.1-rc.1</kernel.bom.version>
-        <kernel.core.version>1.3.1-rc.1</kernel.core.version>
+        <kernel.bom.version>1.3.1-SNAPSHOT</kernel.bom.version>
+        <kernel.core.version>1.3.1-SNAPSHOT</kernel.core.version>
         <kernel.biometrics.api.version>1.3.0</kernel.biometrics.api.version>
     </properties>
 

--- a/mock-mv/pom.xml
+++ b/mock-mv/pom.xml
@@ -5,7 +5,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>io.mosip.mock.mv</groupId>
 	<artifactId>mock-mv</artifactId>
-	<version>1.3.1-rc.1</version>
+	<version>1.3.1-SNAPSHOT</version>
 	<packaging>jar</packaging>
 
 	<name>mock-mv</name>
@@ -59,8 +59,8 @@
 		</sonar.exclusions>
 
 		<!-- Mosip -->
-		<kernel.bom.version>1.3.1-rc.1</kernel.bom.version>
-		<kernel.core.version>1.3.1-rc.1</kernel.core.version>
+		<kernel.bom.version>1.3.1-SNAPSHOT</kernel.bom.version>
+		<kernel.core.version>1.3.1-SNAPSHOT</kernel.core.version>
 	</properties>
 
 	<dependencyManagement>

--- a/mock-sdk/pom.xml
+++ b/mock-sdk/pom.xml
@@ -5,7 +5,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<artifactId>mock-sdk</artifactId>
 	<groupId>io.mosip.mock.sdk</groupId>
-	<version>1.3.1-rc.1</version>
+	<version>1.3.1-SNAPSHOT</version>
 	<name>mock-sdk</name>
 	<description>Sample implementation of biometrics SDK</description>
 	<packaging>jar</packaging>
@@ -54,8 +54,8 @@
 		<sonar.coverage.exclusions>**/constant/**,**/exceptions/**,**/utils/**</sonar.coverage.exclusions>
 
 		<!-- Mosip kernel -->
-		<kernel.bom.version>1.3.1-rc.1</kernel.bom.version>
-		<kernel.core.version>1.3.1-rc.1</kernel.core.version>
+		<kernel.bom.version>1.3.1-SNAPSHOT</kernel.bom.version>
+		<kernel.core.version>1.3.1-SNAPSHOT</kernel.core.version>
 		<kernel.biometrics.api.version>1.3.0</kernel.biometrics.api.version>
 		<kernel.bioconverter.version>1.3.0</kernel.bioconverter.version>
 		<mosip.biometrics.util.version>1.3.0</mosip.biometrics.util.version>


### PR DESCRIPTION
Convert rc versions to SNAPSHOT in pom.xml, update Chart.yaml and install.sh chart_version to 1.3.1-develop, and point values.yaml image repository to mosipqa with tag 1.3.x.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Deployment**
  * Updated deployment charts and installation scripts to use the 1.3.x development release.
  * Updated mock service images to the `mosipqa` repository and 1.3.x image tags.

* **Maintenance**
  * Aligned project components with the 1.3.1-SNAPSHOT platform dependencies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->